### PR TITLE
Adiciona dependencia do JWT no pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt</artifactId>
+      <version>0.9.1</version>
+    </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
# Adiciona dependencia do JWT no pom.xml

### Dependencias adicionadas:
- `JJWT`: Biblioteca para o uso do JWT no Java. JWT é um padrão de token utilizado para autenticação. [Mais informações](https://jwt.io/)