### PR TITLE
Adiciona configuração do H2 no application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
+# H2
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2
 
+spring.jpa.hibernate.ddl-auto=update
+
+spring.datasource.url=jdbc:h2:file:./dados
+spring.datasource.username=admin
+spring.datasource.password=admin
+spring.datasource.driver-class-name=org.h2.Driver
+
+server.servlet.context-path=/api/v1


### PR DESCRIPTION
# Adiciona configuração do H2 no application.properties

### Configurações adicionadas:
- `spring.h2.console.enabled`: Permite o uso do _console_ no _browser_. Valor: `true`;
- `spring.h2.console.path`: Caminho na URL para o `H2`. Valor: `/h2`;
- `spring.datasource.url`: Caminho para o arquivo de dados. Valor: `./dados`;
- `spring.datasource.username`: Usuario usado para login. Valor: `admin`;
- `spring.datasource.password`: Senha usada para login. Valor: `admin`; 
- `server.servlet.context-path`: Caminho padrão da API Valor: `/api/v1`;

### Configurações padrão:
- `spring.jpa.hibernate.ddl-auto`: Valor: `update`; 
- `spring.datasource.driver-class-name`: Valor: `org.h2.driver`; 